### PR TITLE
Fix starting cell orientation

### DIFF
--- a/src/MazeGenerator/Program.cs
+++ b/src/MazeGenerator/Program.cs
@@ -42,8 +42,8 @@ namespace Treboada.Net.Ia
 			// prepare de generator
 			MazeGenerator generator = SetupGenerator (maze);
 
-			// generate from top-left corner
-			generator.Generate (0, 0);
+			// generate from top-left corner, next to the starting cell
+			generator.Generate (1, 0);
 
 			// show the version
 			Console.WriteLine ("OSHWDEM Maze Generator v{0}.{1} R{2}", Version.Major, Version.Minor, Version.Revision);
@@ -61,6 +61,9 @@ namespace Treboada.Net.Ia
 			// square and fully walled
 			Maze maze = new Maze (side, side, Maze.WallInit.Full);
 
+			// set the starting cell
+			maze.UnsetWall (0, 0, Maze.Direction.E);
+
 			// clear the walls inside 2x2 center cells
 			maze.UnsetWall (7, 7, Maze.Direction.S);
 			maze.UnsetWall (7, 7, Maze.Direction.E);
@@ -75,6 +78,9 @@ namespace Treboada.Net.Ia
 		{
 			// pretty algorithm to generate mazes
 			DepthFirst generator = new DepthFirst (maze);
+
+			// starting cell is set
+			generator.SetVisited (0, 0, true);
 
 			// dont enter into the 3x3 center
 			generator.SetVisited (7, 7, true);


### PR DESCRIPTION
According to the international rules:

> The starting point of the maze will be located at one of the four corners of the maze. 
Micromouse starts in a clockwise direction. The finish zone is located on the center 4 
section.

Or:

> The starting square orientation shall be such that when the open wall is to the "North", outside maze walls shall be on the "West" and "South".

This fix simply sets the starting cell orientation before beginning the depth-first generation.

Some references:

- [All Japan](http://www.ntf.or.jp/mouse/micromouse2017/kitei_classic_since2014-EN.html)
- [IEE](http://www.micromouseonline.com/micromouse-book/mazes-and-maze-solving/)
- [AAMC](https://docs.google.com/document/d/1iv-6jBS_YuxvjpPXTylnKEPfILzhPMQqp_KF2RhlVMQ/edit)