### PR TITLE
Quick hack to favor straight paths

### DIFF
--- a/src/MazeGenerator/DepthFirst.cs
+++ b/src/MazeGenerator/DepthFirst.cs
@@ -56,7 +56,7 @@ namespace Treboada.Net.Ia
 		public void Generate(int col, int row)
 		{
 			// explore recursively
-			VisitRec (col, row);
+			VisitRec (col, row, Maze.Direction.E);
 		}
 
 		private static Maze.Direction[] FourRoses = new Maze.Direction[] {
@@ -66,7 +66,7 @@ namespace Treboada.Net.Ia
 			Maze.Direction.W,
 		};
 
-		private void VisitRec(int col, int row)
+		private void VisitRec(int col, int row, Maze.Direction old_direction)
 		{
 			// mark visited
 			Visited [col, row] = true;
@@ -80,6 +80,12 @@ namespace Treboada.Net.Ia
 				// extract one from the list
 				int index = RndFactory.Next () % pending.Count;
 				Maze.Direction direction = pending[index];
+				for (int i = 0; i < 2; i++) {
+					if (direction != old_direction) {
+						index = RndFactory.Next () % pending.Count;
+						direction = pending [index];
+					}
+				}
 				pending.RemoveAt (index);
 
 				// relative to this cell
@@ -110,7 +116,7 @@ namespace Treboada.Net.Ia
 
 					// open the wall and explore recursively
 					Maze.UnsetWall (col, row, direction);
-					VisitRec (c, r);
+					VisitRec (c, r, direction);
 				}
 			}
 


### PR DESCRIPTION
Hablé con Pablo (creo que fue juez de la competición de laberinto en 2017) sobre este tema. Me comentó que habían pensado en poner alguna recta más larga para que fuese más "espectacular" la carrera.

Este parche favorece la elección de "seguir recto" durante el proceso de generación. Básicamente si la nueva dirección no es igual a la anterior, repetimos la selección aleatoria de dirección. En este caso lo he dejado con 2 repeticiones (`i < 2`), pero se puede cambiar el parámetro.

No es la solución más elegante, pero funciona. Por si os interesa para la OSHWDem 2018. :blush:

Con esto se consiguen pasillos de media más largos.

Ejemplos variando el número de repeticiones
----------------------

Con `i < 0` (comportamiento "clásico"):

![0](https://user-images.githubusercontent.com/526577/47109510-b6be3180-d24e-11e8-8568-823eb365a1c6.png)

Con `i < 1`:

![1](https://user-images.githubusercontent.com/526577/47109544-cdfd1f00-d24e-11e8-9ac7-83e5d393a910.png)

Con `i < 2`:

![2](https://user-images.githubusercontent.com/526577/47109550-d2c1d300-d24e-11e8-9dd0-3d251f4e6f7a.png)

Con `i < 3`:

![3](https://user-images.githubusercontent.com/526577/47109555-d6edf080-d24e-11e8-8e07-13dfda84716c.png)
